### PR TITLE
Add meta information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,13 @@
   "version": "0.1.3",
   "main": "src/cli.mjs",
   "types": "src/cli.d.ts",
-  "description": "cross-runtime benchmarking lib"
+  "description": "cross-runtime benchmarking lib",
+	"homepage": "https://github.com/evanwashere/mitata#readme",
+  "bugs": {
+		"url": "https://github.com/evanwashere/mitata/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/evanwashere/mitata.git"
+	},
 }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "main": "src/cli.mjs",
   "types": "src/cli.d.ts",
   "description": "cross-runtime benchmarking lib",
-	"homepage": "https://github.com/evanwashere/mitata#readme",
+    "homepage": "https://github.com/evanwashere/mitata#readme",
   "bugs": {
-		"url": "https://github.com/evanwashere/mitata/issues"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/evanwashere/mitata.git"
-	},
+    "url": "https://github.com/evanwashere/mitata/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/evanwashere/mitata.git"
+  },
 }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,7 @@
   "main": "src/cli.mjs",
   "types": "src/cli.d.ts",
   "description": "cross-runtime benchmarking lib",
-    "homepage": "https://github.com/evanwashere/mitata#readme",
-  "bugs": {
-    "url": "https://github.com/evanwashere/mitata/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/evanwashere/mitata.git"
-  },
+  "homepage": "https://github.com/evanwashere/mitata#readme",
+  "bugs": { "url": "https://github.com/evanwashere/mitata/issues" },
+  "repository": { "type": "git", "url": "git+https://github.com/evanwashere/mitata.git" },
 }


### PR DESCRIPTION
tldr;
If you add the information regarding the repo to the package.json,it would be propagated to npm. 

Currently at vitest it is discussed if we should tinybench/benchmark.js for automated benchmarking. It was recommended to consider mitata. I looked at npm, and there was no link to the repo. So I thought, that the code is not published anywhere. Then somebody posted the link to this repo, and then I could finally look into the code. 

This PR adds the necessary information, to find the repo coming from npm.

https://github.com/vitest-dev/vitest/pull/1029