### PR TITLE
feat: add prepare hook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
 
 ## Examples
 ```js
-import { run, bench, group, baseline } from 'mitata';
+import { run, bench, group, baseline, prepare } from 'mitata';
 
 // deno
 // import { ... } from 'https://esm.sh/mitata';
@@ -22,6 +22,7 @@ bench('noop', () => {});
 bench('noop2', () => {});
 
 group('group', () => {
+  prepare('cleanup', async () => { /* unbenched setup / teardown code' */ })
   baseline('baseline', () => {});
   bench('Date.now()', () => Date.now());
   bench('performance.now()', () => performance.now());

--- a/src/cli.d.ts
+++ b/src/cli.d.ts
@@ -5,6 +5,8 @@ export function group(fn: () => void): void;
 export function group(name: string, fn: () => void): void;
 export function group(options: { name?: string, summary?: boolean }, fn: () => void): void;
 
+export function prepare(name: string, fn: () => any): void;
+
 export function run(options?: {
   avg?: boolean,
   colors?: boolean,

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -32,6 +32,7 @@ export function bench(name, fn) {
     time: 500,
     warmup: true,
     baseline: false,
+    hook: false,
     async: AsyncFunction === fn.constructor,
   });
 };
@@ -47,10 +48,26 @@ export function baseline(name, fn) {
     time: 500,
     warmup: true,
     baseline: true,
+    hook: false,
     async: AsyncFunction === fn.constructor,
   });
 };
 
+export function prepare(name, fn) {
+  if ([Function, AsyncFunction].includes(name.constructor)) (fn = name, name = fn.name);
+  if (![Function, AsyncFunction].includes(fn.constructor)) throw new TypeError(`expected function, got ${fn.constructor.name}`);
+
+  benchmarks.push({
+    fn,
+    name,
+    group: g,
+    time: 500,
+    warmup: false,
+    baseline: false,
+    hook: true,
+    async: AsyncFunction === fn.constructor,
+  });
+}
 let _print;
 
 try {
@@ -204,6 +221,11 @@ export async function run(opts = {}) {
       _f = true;
 
       try {
+        if (b.hook) {
+          await b.fn();
+          continue;
+        }
+
         b.stats = !b.async ? await sync(b.time, b.fn, collect) : await async(b.time, b.fn, collect);
 
         if (!json) log(table.benchmark(b.name, b.stats, opts));
@@ -215,7 +237,7 @@ export async function run(opts = {}) {
       }
     }
 
-    if (_b && !json) log('\n' + table.summary(benchmarks.filter(b => null === b.group), opts));
+    if (_b && !json) log('\n' + table.summary(benchmarks.filter(b => null === b.group && !b.hook), opts));
 
     for (const group of groups) {
       if (!json) {
@@ -229,6 +251,11 @@ export async function run(opts = {}) {
         if (group !== b.group) continue;
 
         try {
+          if (b.hook) {
+            await b.fn();
+            continue;
+          }
+
           b.stats = !b.async ? await sync(b.time, b.fn, collect) : await async(b.time, b.fn, collect);
 
           if (!json) log(table.benchmark(b.name, b.stats, opts));
@@ -240,7 +267,7 @@ export async function run(opts = {}) {
         }
       }
 
-      if (summaries[group] && !json) log('\n' + table.summary(benchmarks.filter(b => group === b.group), opts));
+      if (summaries[group] && !json) log('\n' + table.summary(benchmarks.filter(b => group === b.group && !b.hook), opts));
     }
 
     if (json) log(JSON.stringify(report, null, 'number' !== typeof opts.json ? 0 : opts.json));


### PR DESCRIPTION
This adds a prepare hook, and fixes #12 . I'm not sure about the name, alternatives I've considered were `setup` and `hook`.

It allows people to run code between benchmarks. Think of use cases where the file system needs to be cleaned up, or to create a database index, or other expensive code that the test depends on, but is not part of the test itself.

This change makes the following possible:

```ts
import { baseline, bench, group, prepare, run } from 'mitata';

group('select 10 records using different index strategies', () => {
  prepare('cleanup', async () => {
    await dropAllIndexes();
  })
  
  baseline('baseline, no index', async () => select(10));

  prepare('create index 1', async () => {
    await dropAllIndexes();
    await createIndexOne();
  })
  
  bench('query using index 1',  async() => select(10));

  prepare('create index 2', async () => { 
    await dropAllIndexes();
    await createIndexTwo();
  });
  
  bench('query using index 2',  async() => select(10));
});

await run();
```
