### PR TITLE
refactor: factor out JS runtime detection code

### DIFF
--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -1,6 +1,7 @@
 import { measure } from './lib.mjs';
 import * as kleur from '../reporter/clr.mjs';
 import * as table from '../reporter/table.mjs';
+import { isBrowser, isBun, isDeno, isNode, runtimes } from './utils.mjs';
 
 let _gc = 0;
 let g = null;
@@ -61,10 +62,10 @@ try {
 }
 
 function runtime() {
-  if ('Bun' in globalThis) return 'bun';
-  if ('Deno' in globalThis) return 'deno';
-  if ('process' in globalThis) return 'node';
-  if ('navigator' in globalThis) return 'browser';
+  if (isBun) return runtimes.bun;
+  if (isDeno) return runtimes.deno;
+  if (isNode) return runtimes.node;
+  if (isBrowser) return runtimes.browser;
 
   return 'unknown';
 }

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -1,7 +1,7 @@
 import { measure } from './lib.mjs';
 import * as kleur from '../reporter/clr.mjs';
 import * as table from '../reporter/table.mjs';
-import { isBrowser, isBun, isDeno, isNode, runtimes } from './utils.mjs';
+import { runtime } from './utils.mjs';
 
 let _gc = 0;
 let g = null;
@@ -59,15 +59,6 @@ try {
   if ('function' !== typeof _print) throw 1;
 } catch {
   _print = print;
-}
-
-function runtime() {
-  if (isBun) return runtimes.bun;
-  if (isDeno) return runtimes.deno;
-  if (isNode) return runtimes.node;
-  if (isBrowser) return runtimes.browser;
-
-  return 'unknown';
 }
 
 function version() {

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -1,7 +1,7 @@
 import { measure } from './lib.mjs';
 import * as kleur from '../reporter/clr.mjs';
 import * as table from '../reporter/table.mjs';
-import { runtime } from './utils.mjs';
+import { runtime } from './runtime.mjs';
 
 let _gc = 0;
 let g = null;

--- a/src/runtime.mjs
+++ b/src/runtime.mjs
@@ -1,4 +1,4 @@
-export const runtimes = {
+const runtimes = {
   bun: 'bun',
   deno: 'deno',
   node: 'node',
@@ -9,4 +9,13 @@ export const isBun = 'Bun' in globalThis;
 export const isDeno = 'Deno' in globalThis;
 export const isNode = 'process' in globalThis;
 export const isBrowser = 'navigator' in globalThis;
+
+export function runtime() {
+  if (isBun) return runtimes.bun;
+  if (isDeno) return runtimes.deno;
+  if (isNode) return runtimes.node;
+  if (isBrowser) return runtimes.browser;
+
+  return 'unknown';
+}
 

--- a/src/time.mjs
+++ b/src/time.mjs
@@ -1,4 +1,4 @@
-import { isDeno } from './utils.mjs';
+import { isDeno } from './runtime.mjs';
 
 const time = (() => {
   const ceil = Math.ceil;

--- a/src/time.mjs
+++ b/src/time.mjs
@@ -1,3 +1,5 @@
+import { isDeno } from './utils.mjs';
+
 const time = (() => {
   const ceil = Math.ceil;
 
@@ -5,14 +7,14 @@ const time = (() => {
     Bun.nanoseconds();
 
     return {
-      now: Bun.nanoseconds,
       diff: (a, b) => a - b,
+      now: Bun.nanoseconds,
     };
   } catch { }
 
   try {
+    if (isDeno) throw 0;
     process.hrtime.bigint();
-    if ('Deno' in globalThis) throw 0;
 
     return {
       diff: (a, b) => a - b,

--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -1,0 +1,12 @@
+export const runtimes = {
+  bun: 'bun',
+  deno: 'deno',
+  node: 'node',
+  browser: 'browser',
+};
+
+export const isBun = 'Bun' in globalThis;
+export const isDeno = 'Deno' in globalThis;
+export const isNode = 'process' in globalThis;
+export const isBrowser = 'navigator' in globalThis;
+


### PR DESCRIPTION
It will permit to use the same approach than in `cli.mjs` in `time.mjs` instead of `try {} catch {}` statements