### PR TITLE
fix potential TypeError in groups

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -724,7 +724,8 @@ const formats = {
 
         else {
           let header = false;
-          const baseline = trials.find(([trial, bench]) => bench.baseline && bench.runs.some(r => r.stats)) || trials[0][1];
+          const btrial = trials.find(([trial, bench]) => bench.baseline && bench.runs.some(r => r.stats)) || trials[0];
+          const baseline = btrial && btrial[1];
 
           if (baseline) {
             const bruns = baseline.runs.filter(r => !r.error).sort((a, b) => a.stats.avg - b.stats.avg);


### PR DESCRIPTION
I ran this error while trying #38 

```
file:///home/comet/Workspace/src/github.com/cometkim/unicode-segmenter/node_modules/mitata/src/main.mjs:730
            const bruns = baseline.runs.filter(r => !r.error).sort((a, b) => a.stats.avg - b.stats.avg);
                                        ^

TypeError: Cannot read properties of undefined (reading 'filter')
    at Object.mitata (file:///home/comet/Workspace/src/github.com/cometkim/unicode-segmenter/node_modules/mitata/src/main.mjs:730:41)
    at async run (file:///home/comet/Workspace/src/github.com/cometkim/unicode-segmenter/node_modules/mitata/src/main.mjs:279:3)
    at async file:///home/comet/Workspace/src/github.com/cometkim/unicode-segmenter/benchmark/grapheme/perf.js:117:1
```

Seems the `baseline` type there is `[trial, bench] | bench` unintended