### PR TITLE
Allow passing manual B instances as bench 

### DIFF
--- a/src/main.d.mts
+++ b/src/main.d.mts
@@ -67,6 +67,7 @@ interface k_options {
 
 // ---
 export function bench(fn: () => any): B;
+export function bench(fn: B): B;
 export function do_not_optimize(v: any): void;
 export function bench(name: string, fn: () => any): B;
 export function bench(gen: (state: k_state) => Gen): B;

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -202,10 +202,17 @@ export function lineplot(f) { return _c(f, 'l'); }
 export function group(name, f) { if (typeof name === 'function') (f = name, name = null); return _c(f, 'g', name); }
 
 export function bench(n, fn) {
-  if (typeof n === 'function') (fn = n, n = fn.name || 'anonymous');
+  let b;
+  if(n instanceof B) {
+    b = n
+  }else {
+    if (typeof n === 'function') (fn = n, n = fn.name || 'anonymous');
+    b = new B(n, fn);
+  }
 
   const collection = COLLECTIONS[COLLECTIONS.length - 1];
-  const b = new B(n, fn); b._group = collection.id; return (collection.trials.push(b), b);
+  b._group = collection.id;
+  return (collection.trials.push(b), b);
 }
 
 export function compact(f) {


### PR DESCRIPTION
Using manual B instances lacks other features such as visualization etc.

With this PR, in a simplest way the following example will be possible:

```ts
import { B, bench, run, summary } from "mitata";

summary(() => {
  bench(
    new B("new Array($x)", function* (state) {
      const size = state.get("x");
      yield () => new Array(size);
    })
      .args("x", [1, 5, 10])
      .args("concurrency", [1, 5, 10])
  );
});

await run({ format: "markdown" });

```